### PR TITLE
Allow configuring Dash port via environment

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import base64
 import io
 import json
+import os
 import sqlite3
 from datetime import date, datetime
 from pathlib import Path
@@ -261,4 +262,5 @@ def on_download(n_clicks):
 
 
 if __name__ == "__main__":
-    app.run_server(debug=True)
+    port = int(os.environ.get("PORT", 8050))
+    app.run_server(debug=True, host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- import `os` to read environment variables
- run Dash server on host `0.0.0.0` using `PORT` env variable when set

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb3461e0b08324b8a267a52f5de611