### PR TITLE
Use main.py for Render start

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -4,5 +4,5 @@ services:
     env: python
     plan: free
     buildCommand: pip install -r requirements.txt
-    startCommand: streamlit run app.py --server.port $PORT --server.address 0.0.0.0
+    startCommand: python main.py
     autoDeploy: true


### PR DESCRIPTION
## Summary
- run `main.py` directly in Render deployment
- drop Streamlit server flags now handled by environment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68bb3474147083249ee700cb6ed900ee