### PR TITLE
Allow duplicate update for selected lots

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,7 +235,7 @@ def on_upload(contents, selected):
 
 
 @app.callback(
-    Output("selected-lots", "data"),
+    Output("selected-lots", "data", allow_duplicate=True),
     Input("guardar", "n_clicks"),
     State("selected-lots", "data"),
     State("fecha-riego", "date"),


### PR DESCRIPTION
## Summary
- allow "selected-lots" store to be updated by multiple callbacks
- keep clearing selected lots after saving

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb37c93b048324b098bcbbe95af1f2